### PR TITLE
Fixed migration, refactored response handler

### DIFF
--- a/claim_ai_quality/communication_interface/__init__.py
+++ b/claim_ai_quality/communication_interface/__init__.py
@@ -1,4 +1,4 @@
-from .aiServerCommunicationInterface import *
 from .websocket import *
-from .fhir import *
+from .fhir import ClaimBundleConverter
+from .response_dispatcher import AIResponsePayloadHandlerMixin
 from .aiServerCommunicationInterface import *

--- a/claim_ai_quality/communication_interface/response_dispatcher.py
+++ b/claim_ai_quality/communication_interface/response_dispatcher.py
@@ -1,0 +1,77 @@
+import json
+import asyncio
+from abc import ABC
+
+from typing import Callable, Dict
+
+
+class AbstractPayloadHandler(ABC):
+    @property
+    def type_handlers(self) -> Dict[str, Callable]:
+        raise NotImplementedError('Type handlers not implemented')
+
+    def handle_payload(self, payload):
+        payload_type = payload.get('type', '')
+        return self.type_handlers.get(payload_type, 'default')(payload)
+
+    def dispatch(self, payload: str):
+        payload = json.loads(payload)
+        self.handle_payload(payload)
+
+
+class AIResponsePayloadHandlerMixin(AbstractPayloadHandler):
+
+    @property
+    def type_handlers(self) -> Dict[str, Callable]:
+        return {
+            'claim.bundle.payload': self.claim_response_bundle,
+            'claim.bundle.acceptance': self.acceptance,
+            'claim.bundle.evaluation_exception': self.evaluation_exception,
+            'bundle.authentication_exception': self.authentication_exception,
+            'default': self.default,
+        }
+
+    def claim_response_bundle(self, payload):
+        self.update_claims(payload['content'])
+        index = payload.get('index', None)
+        self.update_response_query(index, 'Valuated')
+        loop = asyncio.get_event_loop()
+        asyncio.ensure_future(
+            self.server_client.send({'type': 'claim.bundle.acceptance', 'content': index})
+        )
+
+    def update_claims(self, fhir_claim_response):
+        # TODO: Use claim repose adjudication for update
+        print("Content of payload hash: " + str(str(fhir_claim_response).__hash__()))
+        pass
+
+    def acceptance(self, payload):
+        self.update_response_query(payload.get('index', None), 'Accepted')
+        print("Bundle was accepted")
+
+    def evaluation_exception(self, payload):
+        self.update_response_query(payload.get('index', None), 'Refused')
+        print(F"Bundle rejected, reason: {payload['content']}")
+
+    def authentication_exception(self, payload):
+        print(F"Connection rejected, reason: {payload['content']}")
+        raise ConnectionError("Invalid authentication token")
+
+    def default(self, payload):
+        print("Uncategorized payload: "+str(payload))
+
+    def update_response_query(self, bundle_index, new_status):
+        if not bundle_index or not new_status:
+            # Response payload didn't affect bundle query
+            return
+        else:
+            self.response_query[bundle_index] = new_status
+
+    @property
+    def _response_type_bundle_status(self):
+        return {
+            'claim.bundle.payload': 'Valuated',
+            'claim.bundle.acceptance': 'Accepted',
+            'claim.bundle.evaluation_exception': 'Refused'
+        }
+

--- a/claim_ai_quality/migrations/0001_initial_migration.py
+++ b/claim_ai_quality/migrations/0001_initial_migration.py
@@ -3,7 +3,6 @@
 from django.db import migrations
 from claim.models import Claim, ClaimItem, ClaimService
 
-
 def _empty_ai_quality_json():
     return {"was_categorized": False, "request_time": None, "response_time": None}
 
@@ -29,6 +28,7 @@ def _add_claim_json_entry(claim):
             # No categorization for claims that were just entered
             pass
     claim.json_ext = current_json
+    claim.save_history()
     claim.save()
 
 
@@ -39,18 +39,19 @@ def _add_claim_item_entry(claim_item):
             "ai_result": str(claim_item.status)
         }
         claim_item.json_ext = current_json
+        claim_item.save_history()
         claim_item.save()
 
 
 def claim_ai_quality_initial(apps, schema_editor):
-    for claim in Claim.objects.all():
-        _add_claim_json_entry(claim)
-
-    for item in ClaimItem.objects.all():
+    for item in ClaimItem.objects.filter(validity_to=None).all():
         _add_claim_item_entry(item)
 
-    for service in ClaimService.objects.all():
+    for service in ClaimService.objects.filter(validity_to=None).all():
         _add_claim_item_entry(service)
+
+    for claim in Claim.objects.filter(validity_to=None).all():
+        _add_claim_json_entry(claim)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
This PR fixes a migration issue that caused incorrect assignment of values to versioned claims, which resulted in claims without any items/services being sent. 
PR also includes a refactor of the server response handling. The logic for processing specific types of responses has been moved to a separate mixin class.