### PR TITLE
OAI-38: Resolve claim_repsonse update issues

### DIFF
--- a/claim_ai_quality/communication_interface/aiServerCommunicationInterface.py
+++ b/claim_ai_quality/communication_interface/aiServerCommunicationInterface.py
@@ -3,9 +3,11 @@ import uuid
 
 from asgiref.sync import sync_to_async
 from claim.models import Claim
+from core import TimeUtils
 from itertools import groupby
 from datetime import datetime
 from django.core.paginator import Paginator
+from django.db import transaction
 
 from . import AIResponsePayloadHandlerMixin
 from .websocket import AbstractFHIRWebSocket
@@ -16,18 +18,22 @@ class AiServerCommunicationInterface(AIResponsePayloadHandlerMixin, AbstractFHIR
 
     async def send_all(self):
         self.response_query = {}
-        data = await self._get_imis_data()  # generator of paginated data
-        next_bundle = await self._get_from_iterator(data)  # first bundle of claims
+        data = self._get_imis_data()  # generator of paginated data
 
-        while next_bundle:
-            asyncio.ensure_future(self.__async_bundle_send(next_bundle))
+        while True:
             next_bundle = await self._get_from_iterator(data)
+            if next_bundle:
+                asyncio.ensure_future(self.__async_bundle_send(next_bundle))
+                pass
+            else:
+                break
+
+        await self.sustain_connection()
 
     async def __async_bundle_send(self, next_bundle):
         bundle_id = str(uuid.uuid4())
         self.response_query[bundle_id] = 'Sent'
         self.send_bundle(next_bundle, bundle_id)
-        await self.sustain_connection()
 
     async def on_receive(self, message):
         await self.__dispatch(message)
@@ -45,7 +51,7 @@ class AiServerCommunicationInterface(AIResponsePayloadHandlerMixin, AbstractFHIR
         loop = asyncio.get_event_loop()
         task = loop.create_task(self.send_data_bundle(bundle, data_type='claim.bundle.payload', bundle_id=bundle_id))
         for claim in bundle:
-            claim.json_ext['claim_ai_quality']['request_time'] = datetime.now()
+            asyncio.ensure_future(self._save_claim_request_time(claim.id))
 
         asyncio.ensure_future(task)
 
@@ -54,19 +60,27 @@ class AiServerCommunicationInterface(AIResponsePayloadHandlerMixin, AbstractFHIR
         task = asyncio.create_task(coro)
         return await task
 
-    @sync_to_async
     def _get_imis_data(self):
+        l = []
+        for x in range(15200, 15380):
+            l.append(x)
+        print(l)
         queryset = Claim.objects\
             .filter(json_ext__jsoncontains={'claim_ai_quality': {'was_categorized': False}},
                     validity_to__isnull=True)\
             .filter(json_ext__jsoncontains={'claim_ai_quality': {'request_time': None}}) \
+            .filter(id__in=l) \
             .prefetch_related("items") \
             .prefetch_related("services") \
-            .order_by('id')\
-            .all()
-        paginator = Paginator(queryset, ClaimAiQualityConfig.bundle_size)
-        for page in range(1, paginator.num_pages + 1):
-            yield paginator.page(page).object_list
+            .order_by('id')
+
+        next_set = []
+        for obj in queryset:
+            if len(next_set) >= ClaimAiQualityConfig.bundle_size:
+                yield list(next_set)
+                next_set = []
+            next_set.append(obj)
+        yield list(next_set)
 
     @sync_to_async
     def _get_from_iterator(self, queryset):
@@ -93,3 +107,9 @@ class AiServerCommunicationInterface(AIResponsePayloadHandlerMixin, AbstractFHIR
                 break
             await asyncio.sleep(0)
             continue
+
+    @sync_to_async
+    def _save_claim_request_time(self, claim_id):
+        claim = Claim.objects.get(id=claim_id)
+        claim.json_ext['claim_ai_quality']['request_time'] = str(TimeUtils.now())
+        claim.save()

--- a/claim_ai_quality/communication_interface/fhir/_claim_response_converter.py
+++ b/claim_ai_quality/communication_interface/fhir/_claim_response_converter.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
-
+from itertools import groupby
+from core import TimeUtils
 from claim.models import Claim, ClaimDetail
 from django.db import transaction
 from medical.models import Item, Service
@@ -16,7 +17,7 @@ class ClaimResponseConverter:
     def update_claim(self, claim_response: dict):
         # change claim status to select for review if any rejected items
         try:
-            claim = Claim.objects.get(uuid=claim_response['id'], validity_to__isnull=True)
+            claim = Claim.objects.select_for_update().get(uuid=claim_response['id'], validity_to__isnull=True)
             if self._response_have_rejected_items(claim_response):
                 self.__set_evaluated_review_status(claim)
 
@@ -42,27 +43,16 @@ class ClaimResponseConverter:
         return False
 
     def _update_items_status(self, claim, claim_response):
-        for item in claim_response['item']:
-            provided = self._get_claim_item_by_claim_response_item(claim, item)
-            if provided is None:
-                continue
-            adjudication = self._get_item_adjudication(item)
+        grouped_items = self._group_items(claim_response['item'])
 
-            # change item status and service status to rejected if adjudication.category == 1
-            if adjudication == ClaimAiQualityConfig.rejected_category_code:
-                provided.rejection_reason = ClaimAiQualityConfig.reason_rejected_by_ai_code
-                provided.status = ClaimDetail.STATUS_REJECTED
-
-            # jsonExt set to true, add ai_result = adjudiction.category + 1
-            json_ext = provided.json_ext or {}
-            json_ext['claim_ai_quality'] = self._create_item_ai_quality_json_ext(adjudication)
-            provided.json_ext = json_ext
-            provided.save()
+        for provided_key, claim_provisions in grouped_items:
+            for index, item in enumerate(list(claim_provisions)):
+                self._update_single_item(item, claim)
 
     def _update_claim_json_ext(self, claim):
         json_ext = claim.json_ext or {}
         json_ext['claim_ai_quality']['was_categorized'] = True
-        json_ext['claim_ai_quality']['response_time'] = str(datetime.now())
+        json_ext['claim_ai_quality']['response_time'] = str(TimeUtils.now())
         claim.json_ext = json_ext
 
     def _create_item_ai_quality_json_ext(self, item_adjudication):
@@ -77,9 +67,17 @@ class ClaimResponseConverter:
     def _get_claim_item_by_claim_response_item(self, claim, item):
         category, item_id = item['extension'][0]['valueReference']['reference'].split('/')
         if category == 'Medication':
-            provided = claim.items.filter(item__uuid=item_id, validity_to__isnull=True).first()
+            provided = claim.items \
+                .select_for_update() \
+                .filter(item__uuid=item_id, validity_to__isnull=True)\
+                .order_by('validity_from')\
+                .first()
         elif category == 'ActivityDefinition':
-            provided = claim.services.filter(service__uuid=item_id, validity_to__isnull=True).first()
+            provided = claim.services \
+                .select_for_update() \
+                .filter(service__uuid=item_id, validity_to__isnull=True)\
+                .order_by('validity_from')\
+                .first()
         else:
             raise ValueError(F"Invalid provided item of type: {category}")
 
@@ -88,3 +86,26 @@ class ClaimResponseConverter:
             item = model.objects.filter(uuid=item_id).first()
             logger.warning(F"Couldn't match item {item.code} ({item.name}) with claim {claim.code}")
         return provided
+
+    def _group_items(self, items):
+        return groupby(items, key=lambda item: item['extension'][0]['valueReference']['reference'])
+
+    def _update_single_item(self, item, claim,):
+        provided = self._get_claim_item_by_claim_response_item(claim, item)
+        if provided is None:
+            return
+
+        provided.save_history()
+        adjudication = self._get_item_adjudication(item)
+
+        # change item status and service status to rejected if adjudication.category == 1
+        if adjudication == ClaimAiQualityConfig.rejected_category_code:
+            provided.rejection_reason = ClaimAiQualityConfig.reason_rejected_by_ai_code
+            provided.status = ClaimDetail.STATUS_REJECTED
+
+        # jsonExt set to true, add ai_result = adjudiction.category + 1
+        json_ext = provided.json_ext or {}
+        json_ext['claim_ai_quality'] = self._create_item_ai_quality_json_ext(adjudication)
+        provided.json_ext = json_ext
+        provided.validity_from = TimeUtils.now()
+        provided.save()


### PR DESCRIPTION
This PR fixes few issues regarding sending claim bundles and updating claims with response data: 
- Many items/services of the same type linked to one claim response are handled (previously only one item/service was updated)
- Chunks are created with queryset iterator instead of Paginator which caused some data to be omitted
- Saving request and response time in json_ext fixed