### PR TITLE
OAI-47: Remove deadlock ocurring on empty query

### DIFF
--- a/claim_ai_quality/communication_interface/aiServerCommunicationInterface.py
+++ b/claim_ai_quality/communication_interface/aiServerCommunicationInterface.py
@@ -19,14 +19,19 @@ class AiServerCommunicationInterface(AIResponsePayloadHandlerMixin, AbstractFHIR
     async def send_all(self):
         self.response_query = {}
         data = self._get_imis_data()  # generator of paginated data
+        data_sent = False
 
         while True:
             next_bundle = await self._get_from_iterator(data)
             if next_bundle:
+                data_sent = True
                 asyncio.ensure_future(self.__async_bundle_send(next_bundle))
                 pass
             else:
-                break
+                if data_sent:
+                    break
+                else:
+                    return
 
         await self.sustain_connection()
 

--- a/claim_ai_quality/tests/test_fhir_converter.py
+++ b/claim_ai_quality/tests/test_fhir_converter.py
@@ -1,16 +1,25 @@
 from api_fhir_r4.serializers import ClaimSerializer
 from claim.models import Claim
 from claim.test_helpers import create_test_claim, create_test_claimservice, create_test_claimitem
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from .test_response_bundle import adjudication_bundle, custom_bundle
 from ..communication_interface import ClaimBundleConverter
 
 
-class TestClaimBundleConverter(TestCase):
+class TestClaimBundleConverter(TransactionTestCase):
     FHIR_CONVERTER = ClaimBundleConverter(ClaimSerializer())
 
     def setUp(self) -> None:
         self._build_claim()
+        
+    def tearDown(self) -> None:
+        for i in self.TEST_CLAIM.items.all():
+            i.delete()
+
+        for s in self.TEST_CLAIM.services.all():
+            s.delete()
+
+        self.TEST_CLAIM.delete()
 
     def test_claim_response_transformation(self):
         self.FHIR_CONVERTER.update_claims_by_response_bundle(self.TEST_RESPONSE_BUNDLE)
@@ -31,7 +40,7 @@ class TestClaimBundleConverter(TestCase):
 
     def test_claim_response_transformation_all_valid(self):
         test_claim_response = self.TEST_RESPONSE_BUNDLE.copy()
-        test_claim_response['entry'][0]['item'][1]['adjudication'][0]['reason']['coding'][0]['code'] = 0
+        test_claim_response['entry'][0]['resource']['item'][1]['adjudication'][0]['reason']['coding'][0]['code'] = 0
 
         self.FHIR_CONVERTER.update_claims_by_response_bundle(self.TEST_RESPONSE_BUNDLE)
 
@@ -48,15 +57,14 @@ class TestClaimBundleConverter(TestCase):
         self.assertEqual(claim.json_ext['claim_ai_quality']['was_categorized'], True)
         self.assertNotEqual(claim.review_status, 4)
 
-    @classmethod
-    def _build_claim(cls):
-        cls.TEST_CLAIM = create_test_claim()
-        cls.TEST_CLAIM.json_ext = {'claim_ai_quality': {'was_categorized': False}}
-        cls.TEST_CLAIM.save()
-        cls.TEST_CLAIM_ITEM = create_test_claimitem(cls.TEST_CLAIM, 'D')
-        cls.TEST_CLAIM_ITEM.save()
-        cls.TEST_CLAIM_SERVICE = create_test_claimservice(cls.TEST_CLAIM, 'S')
-        cls.TEST_CLAIM_SERVICE.save()
-        cls.TEST_RESPONSE_BUNDLE = custom_bundle(cls.TEST_CLAIM.uuid,
-                                                 cls.TEST_CLAIM_ITEM.item.uuid,
-                                                 cls.TEST_CLAIM_SERVICE.service.uuid)
+    def _build_claim(self):
+        self.TEST_CLAIM = create_test_claim()
+        self.TEST_CLAIM.json_ext = {'claim_ai_quality': {'was_categorized': False}}
+        self.TEST_CLAIM.save()
+        self.TEST_CLAIM_ITEM = create_test_claimitem(self.TEST_CLAIM, 'D')
+        self.TEST_CLAIM_ITEM.save()
+        self.TEST_CLAIM_SERVICE = create_test_claimservice(self.TEST_CLAIM, 'S')
+        self.TEST_CLAIM_SERVICE.save()
+        self.TEST_RESPONSE_BUNDLE = custom_bundle(self.TEST_CLAIM.uuid,
+                                                  self.TEST_CLAIM_ITEM.item.uuid,
+                                                  self.TEST_CLAIM_SERVICE.service.uuid)

--- a/claim_ai_quality/tests/test_response_bundle.py
+++ b/claim_ai_quality/tests/test_response_bundle.py
@@ -2,6 +2,12 @@ adjudication_bundle = {
     'resourceType': 'AdjudicationBundle',
     'entry': [
         {
+            'fullUrl': 'localhost',
+            'resource': {
+                "resourceType": 'ClaimResponse',
+                "status": 'active',
+                "type": {'text': "R"},
+                "outcome": 'complete',
                 "insurer": {
                     "reference": "Organization/openIMIS-Claim-AI"
                 },
@@ -89,15 +95,16 @@ adjudication_bundle = {
                 ],
                 "use": "claim"
             }
+        }
     ]
 }
 
 
 def custom_bundle(claim_uuid, item_uuid, service_uuid):
     bundle = adjudication_bundle.copy()
-    claim = bundle['entry'][0]
+    claim = bundle['entry'][0]['resource']
     claim['id'] = claim_uuid
     claim['item'][0]['extension'][0]['valueReference']['reference'] = F'Medication/{item_uuid}'
     claim['item'][1]['extension'][0]['valueReference']['reference'] = F'ActivityDefinition/{service_uuid}'
-    bundle['entry'][0] = claim
+    bundle['entry'][0]['resource'] = claim
     return bundle


### PR DESCRIPTION
If queryset return None instead of claims connection was sustained  indefinitely