### PR TITLE
Fixed condition for sending event based activation

### DIFF
--- a/claim_ai_quality/schema.py
+++ b/claim_ai_quality/schema.py
@@ -41,7 +41,11 @@ def on_claim_mutation(sender: dispatcher.Signal, **kwargs):
     if not uuids:
         return []
 
+    claims = Claim.objects.filter(uuid__in=uuids)
     all_submitted_claims = add_json_ext_to_all_submitted_claims()
+    for c in claims.all():
+        if c not in all_submitted_claims:
+            all_submitted_claims.append(c)
 
     if ClaimAiQualityConfig.event_based_activation:
         _send_submitted_claims(all_submitted_claims)


### PR DESCRIPTION
If claim was submitted but  had already assigned claim_ai_quality value in case of event_based_activation it was not sent for evaluation.