### PR TITLE
OAI-48: Disable checking jsonExt consistency for all submitted claims

### DIFF
--- a/claim_ai_quality/schema.py
+++ b/claim_ai_quality/schema.py
@@ -42,7 +42,7 @@ def on_claim_mutation(sender: dispatcher.Signal, **kwargs):
         return []
 
     claims = Claim.objects.filter(uuid__in=uuids)
-    add_json_ext_to_all_submitted_claims()
+    add_json_ext_to_all_submitted_claims(claims)
     claims_for_evaluation = []
     for c in claims.all():
         if c.status == Claim.STATUS_CHECKED:

--- a/claim_ai_quality/utils.py
+++ b/claim_ai_quality/utils.py
@@ -67,14 +67,15 @@ def add_json_ext_to_items_and_services(claim):
 
 
 @transaction.atomic
-def add_json_ext_to_all_submitted_claims():
-    all_submitted_claims = Claim.objects\
-        .select_for_update()\
-        .filter(
-            status__in=(Claim.STATUS_CHECKED, Claim.STATUS_REJECTED),
-            validity_to__isnull=True) \
-        .annotate(ext_as_str=Cast('json_ext', TextField()))\
-        .exclude(ext_as_str__icontains='claim_ai_quality')
+def add_json_ext_to_all_submitted_claims(all_submitted_claims=None):
+    if all_submitted_claims is None:
+        all_submitted_claims = Claim.objects\
+            .select_for_update()\
+            .filter(
+                status__in=(Claim.STATUS_CHECKED, Claim.STATUS_REJECTED),
+                validity_to__isnull=True) \
+            .annotate(ext_as_str=Cast('json_ext', TextField()))\
+            .exclude(ext_as_str__icontains='claim_ai_quality')
 
     claims_for_ai_evaluation = []
     for claim in all_submitted_claims:


### PR DESCRIPTION
Disable checking consistency of jsonExt for claims that could be submitted by mobile in event based activation due to time consuming query. 